### PR TITLE
Modifica o Totals.php para não mostrar "juros" em pedidos que não têm juros

### DIFF
--- a/app/code/community/MageShop/PagarMe/Block/Sales/Order/Totals.php
+++ b/app/code/community/MageShop/PagarMe/Block/Sales/Order/Totals.php
@@ -16,7 +16,7 @@ class MageShop_PagarMe_Block_Sales_Order_Totals extends Mage_Sales_Block_Order_T
         $data = [];
         $data['code']  = 'juros';
         $data['field'] = 'juros';
-        $data['value'] = 11;
+        $data['value'] = 0;
         $data['label'] = 'Juros: ';
         $this->addTotalBefore(new Varien_Object($data), 'grand_total');
 


### PR DESCRIPTION
Modificado o valor da linha "19", de 11 para 0.

O $data['value'] = 11; 
O valor era mostrado em todos os pedidos (incluindo PIX e Boleto) como sendo Juros: R$ 11,00, seja no painel do cliente, como no e-mail disparado após a venda. Isto, pois o valor deveria ser 0, uma vez que ele adiciona abaixo o "if" para condicionar que se o valor for maior que 0, há a informação dos juros cobraddos.